### PR TITLE
Fix image path in handler and update image reference in posts.yaml

### DIFF
--- a/content/posts/ramadan/posts.yaml
+++ b/content/posts/ramadan/posts.yaml
@@ -10,7 +10,7 @@
           باسم منظمة @shar3.kassala
   hashtags: ["رمضان", "شارع_الحوادث", "السودان", "الخير_في_رمضان"]
   platforms: ["twitter", "facebook"]
-  image: "ramadan/ramadan-poster.png"
+  image: "ramadan-poster.png"
 
 - post_id: ramadan_002
   text: |
@@ -24,7 +24,7 @@
           باسم منظمة @shar3.kassala
   hashtags: ["رمضان", "شارع_الحوادث", "السودان", "الخير_في_يدينا"]
   platforms: ["twitter", "facebook"]
-  image: "ramadan/ramadan-poster.png"
+  image: "ramadan-poster.png"
 
 - post_id: ramadan_003
   text: |
@@ -38,7 +38,7 @@
           باسم منظمة @shar3.kassala
   hashtags: ["رمضان", "شارع_الحوادث", "السودان", "الخير_ما_بيتوقف"]
   platforms: ["twitter", "facebook"]
-  image: "ramadan/ramadan-poster.png"
+  image: "ramadan-poster.png"
 
 - post_id: ramadan_004
   text: |
@@ -53,7 +53,7 @@
           باسم منظمة @shar3.kassala
   hashtags: ["رمضان", "شارع_الحوادث", "السودان", "الخير_في_رمضان"]
   platforms: ["facebook"]
-  image: "ramadan/ramadan-poster.png"
+  image: "ramadan-poster.png"
 
 - post_id: ramadan_005
   text: |
@@ -68,7 +68,7 @@
           باسم منظمة @shar3.kassala
   hashtags: ["رمضان", "شارع_الحوادث", "السودان", "الخير_في_يدينا"]
   platforms: ["facebook"]
-  image: "ramadan/ramadan-poster.png"
+  image: "ramadan-poster.png"
 
 - post_id: ramadan_006
   text: |
@@ -82,4 +82,4 @@
           باسم منظمة @shar3.kassala
   hashtags: ["رمضان", "شارع_الحوادث", "السودان", "الخير_ما_بيتوقف"]
   platforms: ["facebook"]
-  image: "ramadan/ramadan-poster.png"
+  image: "ramadan-poster.png"

--- a/src/utils/image_handler.py
+++ b/src/utils/image_handler.py
@@ -5,7 +5,7 @@ from ..config import IMAGE_DIR
 class ImageHandler:
     @staticmethod
     def get_image_path(post_type, image_name):
-        return Path(IMAGE_DIR) / image_name
+        return Path(IMAGE_DIR) / post_type / image_name
 
     @staticmethod
     def resize_image(image_path, max_size=(1200, 1200)):


### PR DESCRIPTION
This commit addresses the following issues:

**1. Fix Image Path in `image_handler.py`**:

- Updated the `get_image_path method` in `src/utils/image_handler.py` to correctly resolve the image path by including the post_type directory, ensuring the images are fetched from the appropriate folder.

**2. Update Image Reference in `posts.yaml`:**

- Modified the image field in `content/posts/ramadan/posts.yaml` to reference the correct image file name (`ramadan-poster.png`) without the unnecessary subfolder (`ramadan/`). This change ensures the images are found and processed correctly during the post creation process.