### PR TITLE
Remove image attachment for Twitter posts and adjust image handling l…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -102,14 +102,13 @@ def main(post_type):
                     logging.error(f"Failed to format post for {platform}. Skipping.")
                     continue
 
-                # Get the image path if available
+                # Get the image path if available (skip for Twitter)
                 image_path = None
-                if "image" in post:
+                if platform != "twitter" and "image" in post:
                     try:
                         image_path = ImageHandler.get_image_path(post_type, post["image"])
                     except Exception as e:
                         logging.error(f"Error loading image for {platform}: {e}")
-
                 # Post to the platform
                 handler = SocialFactory.get_handler(platform)
                 handler.post(formatted_text, image_path)


### PR DESCRIPTION
…ogic

## Changes:

- Updated main function to prevent image attachment for Twitter posts.
- Modified image retrieval logic to skip image handling when posting to Twitter.
- Ensured images are only attached for non-Twitter platforms.

## Why this change?

- Twitter API limitations required manual image posting, so the image is now excluded from automated posts on Twitter and will be added via URL in the post.