### PR TITLE
Fix YAML syntax error in posts.yaml by removing trailing commas

### DIFF
--- a/content/posts/daily/posts.yaml
+++ b/content/posts/daily/posts.yaml
@@ -10,7 +10,7 @@
           باسم منظمة #شارع_الحوادث
   hashtags: ["شارع_الحوادث", "السودان", "الخير_في_يدينا"]
   platforms: ["twitter", "facebook"]
-  image: "daily/daily_001.png",
+  image: "daily/daily_001.png"
 
 - post_id: daily_002
   text: |


### PR DESCRIPTION
- Removed trailing commas after the 'image' field in the posts.yaml file to resolve YAML parsing error. This fix ensures proper YAML syntax and prevents the error when running the daily posts automation.