### PR TITLE
Fix(image paths): dynamically generate image filenames based on post …

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -210,7 +210,12 @@ def prepare_post_content(post, platform, current_image_index, post_type):
     if not formatted_text:
         return None, None, None
 
-    image_files = ["daily_001.png", "daily_002.jpg"]
+    # Generate image filenames based on post_type
+    image_files = [
+        f"{post_type}_001.png",
+        f"{post_type}_002.jpg"
+    ]
+
     next_image_index = (current_image_index + 1) % len(image_files)
 
     try:


### PR DESCRIPTION
…type

- Updated prepare_post_content() to use post_type in image filenames (e.g. friday_001.png)
- Ensures correct image paths for different post types (friday/daily)
- Fixes FileNotFoundError when posting Friday content

Previously hardcoded 'daily' image names caused errors for Friday posts. Now properly looks for type-specific images in their respective directories.