### PR TITLE
Fix: resolve absolute paths for content directories to prevent file n…

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -34,6 +34,7 @@ PLATFORMS = {
 }
 
 # Directory paths for content, images, and posts
-CONTENT_DIR = os.path.join(os.path.dirname(__file__), "../content")
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONTENT_DIR = os.path.join(BASE_DIR, "content")
 IMAGE_DIR = os.path.join(CONTENT_DIR, "images")
 POSTS_DIR = os.path.join(CONTENT_DIR, "posts")


### PR DESCRIPTION
…ot found errors

- Updated `config.py` to use `os.path.abspath()` for reliable path resolution
- Replaced relative `../` paths with absolute paths derived from BASE_DIR
- Ensures consistent behavior across different working directories (local/CI)
- Added debug logging to help verify resolved paths
- Maintains existing directory structure but prevents ../ issues in GitHub Actions

This fixes the error:
"ERROR - Error processing facebook: [Errno 2] No such file or directory: '/home/runner/work/sara-social-media-bot/sara-social-media-bot/src/../content/images/friday/friday_001.png'"